### PR TITLE
Bug selector hidden top bar (Discord use bar_* classe in others parts)

### DIFF
--- a/main.css
+++ b/main.css
@@ -50,7 +50,7 @@
 		:root {
 			--custom-app-top-bar-height: 0;
 		}
-		div[class^="bar"] {
+		div[class^="base_"] > div[class^="bar_"] {
 			display: none;
 		}
 		nav[aria-label="Servers sidebar"] {


### PR DESCRIPTION
Sorry, i recreate PR with your syntaxe  (div[--]> div[--])
Hi : The current selector:

```css
div[class^="bar"] {
  display: none;
}
```
is too broad and can glitch

Discord uses class names like ```bar__*``` in many unrelated parts of the interface, **not just the top bar.**
https://github.com/Lantea-Git/Skin_CSS/issues/1

---

You can Use a more specific selector :

```css
div[class^="base_"] > div[class^="bar_"] {
```


This works because the top bar is the only `bar_` direct child of base. (in my PR)
https://github.com/birb-naise/Customizable-Discord/pull/2/files

also you can force bar_ with only one underscore .

```css
div[class^="bar_"]:not([class^="bar__"]) {
```

This excludes all elements using `bar__`, which are often unrelated and appear in other parts of the UI.

Discord use this class in a lot of elements totally differently. 👀
